### PR TITLE
Configure typos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,12 @@ base64 = "0.22.1"
 pico-args = "0.5"
 tiny-skia-path = "0.11.4"
 xmlwriter = "0.1"
+
+[package.metadata.typos.default]
+locale = "en-us"
+
+[package.metadata.typos.default.extend-words]
+loca = "loca"
+ot = "ot"
+trak = "trak"
+wdth = "wdth"


### PR DESCRIPTION
As a follow up to @waywardmonkeys recent commit fixing typos, this configures the tool `typos` such that it can be used out of the box without producing false positives.