### PR TITLE
Document change to MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59.0
+          - 1.63.0
           - stable
     steps:
     - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/RazrFalcon/ttf-parser"
 documentation = "https://docs.rs/ttf-parser/"
 readme = "README.md"
 edition = "2018"
+rust-version = "1.63.0"
 exclude = ["benches/**"]
 
 [dependencies]


### PR DESCRIPTION
1.63.0 is the MSVR of the libm crate version used in our manifest and seems to be the current lowest common denominator. It is only used when building no-std, but I don't see any documentation that the MSVR for this project can/should be separate for default features vs. non-default features.