### PR TITLE
Relax dependency pinning from patch to minor level only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ glyph-names = []
 gvar-alloc = ["std"]
 
 [dev-dependencies]
-base64 = "0.22.1"
+base64 = "0.22"
 pico-args = "0.5"
-tiny-skia-path = "0.11.4"
+tiny-skia-path = "0.11"
 xmlwriter = "0.1"
 
 [package.metadata.typos.default]


### PR DESCRIPTION
This is a parallel to https://github.com/harfbuzz/rustybuzz/pull/153 and comments should probably be pursued there.

The only differences are:

* This crate has very few and relatively slow moving depnedencies, so it is less of an issue.
* This project doesn't track a lock file (yet). We could certainly start doing there is a need to do so, but it could factor in to regression testing when not having patch-level pinned dependencies in the manifest.
