### PR TITLE
Call push_clip() and pop_clip() when painting COLRv0 glyphs

### DIFF
--- a/src/tables/colr.rs
+++ b/src/tables/colr.rs
@@ -825,8 +825,8 @@ impl<'a> Table<'a> {
 
     /// Returns `true` if the current table has version 0.
     ///
-    /// A simple table can only emit `outline_glyph` and `paint`
-    /// [`Painter`] methods.
+    /// A simple table can only emit `outline_glyph`, `paint`, `push_clip`, and
+    /// `pop_clip` [`Painter`] methods.
     pub fn is_simple(&self) -> bool {
         self.version == 0
     }
@@ -937,15 +937,16 @@ impl<'a> Table<'a> {
         let layers = self.layers.slice(start..end)?;
 
         for layer in layers {
+            painter.outline_glyph(layer.glyph_id);
+            painter.push_clip();
             if layer.palette_index == 0xFFFF {
                 // A special case.
-                painter.outline_glyph(layer.glyph_id);
                 painter.paint(Paint::Solid(foreground_color));
             } else {
                 let color = self.palettes.get(palette, layer.palette_index)?;
-                painter.outline_glyph(layer.glyph_id);
                 painter.paint(Paint::Solid(color));
             }
+            painter.pop_clip();
         }
 
         Some(())

--- a/tests/tables/colr.rs
+++ b/tests/tables/colr.rs
@@ -65,23 +65,35 @@ fn basic() {
     assert_eq!(
         paint(2).unwrap(), vec![
             Command::OutlineGlyph(GlyphId(12)),
+            Command::PushClip,
             Command::Paint(c.clone()),
+            Command::PopClip,
             Command::OutlineGlyph(GlyphId(13)),
-            Command::Paint(a.clone())]
-    );
+            Command::PushClip,
+            Command::Paint(a.clone()),
+            Command::PopClip
+        ]);
 
     assert_eq!(paint(3).unwrap(), vec![
         Command::OutlineGlyph(GlyphId(10)),
+        Command::PushClip,
         Command::Paint(c.clone()),
+        Command::PopClip,
         Command::OutlineGlyph(GlyphId(11)),
+        Command::PushClip,
         Command::Paint(b.clone()),
+        Command::PopClip,
         Command::OutlineGlyph(GlyphId(12)),
+        Command::PushClip,
         Command::Paint(c.clone()),
+        Command::PopClip,
     ]);
 
     assert_eq!(paint(7).unwrap(), vec![
         Command::OutlineGlyph(GlyphId(11)),
+        Command::PushClip,
         Command::Paint(b.clone()),
+        Command::PopClip,
     ]);
 }
 


### PR DESCRIPTION
Necessary for getting the proper glyph extents in rustybuzz, and [matches HarfBuzz](https://github.com/harfbuzz/harfbuzz/blob/92af2e47fc88a960172367e8a53262d2bab17a51/src/OT/Color/COLR/COLR.hh#L2747-L2753).

We can't solve this solely in rustybuzz by just checking if the COLR table is v0 and behaving differently if so, because we can have COLRv0 glyphs in a COLRv1 table.