### PR TITLE
Exclude test data and tools from published packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/ttf-parser/"
 readme = "README.md"
 edition = "2018"
 rust-version = "1.63.0"
-exclude = ["benches/**"]
+exclude = ["benches/", "tests/", "testing-tools/", "examples/", "meson.build"]
 
 [dependencies]
 core_maths = { version = "0.1.0", optional = true } # only for no_std builds


### PR DESCRIPTION
During our dependency reviews we discovered that the ttf-parser crate as uploaded to crates.io includes test data and additional tools that are not used by the rust code. This increases the package size and makes it harder to review the source code.

This commit explicitly includes only relevant files. This helps to reduce the package size

Before: 118 files, 1.0MiB (198.4KiB compressed)
After: 75 files, 747.1KiB (140.6KiB compressed)

Overall based on the reduction in the compressed package size and the current download numbers that results to a traffic reduction for crates.io of around 110GB / Month.