### PR TITLE
Fix mismatched_lifetime_syntaxes warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2245,7 +2245,7 @@ impl<'a> Face<'a> {
         &self,
         glyph_id: GlyphId,
         pixels_per_em: u16,
-    ) -> Option<RasterGlyphImage> {
+    ) -> Option<RasterGlyphImage<'_>> {
         if let Some(table) = self.tables.sbix {
             if let Some(strike) = table.best_strike(pixels_per_em) {
                 return strike.get(glyph_id);

--- a/src/tables/cff/cff1.rs
+++ b/src/tables/cff/cff1.rs
@@ -799,7 +799,7 @@ fn parse_sid_metadata<'a>(
     Some(FontKind::SID(metadata))
 }
 
-fn parse_cid_metadata(data: &[u8], top_dict: TopDict, number_of_glyphs: u16) -> Option<FontKind> {
+fn parse_cid_metadata(data: &[u8], top_dict: TopDict, number_of_glyphs: u16) -> Option<FontKind<'_>> {
     let (charset_offset, fd_array_offset, fd_select_offset) = match (
         top_dict.charset_offset,
         top_dict.fd_array_offset,

--- a/src/tables/glyf.rs
+++ b/src/tables/glyf.rs
@@ -484,7 +484,7 @@ fn outline_impl(
 pub(crate) fn parse_simple_outline(
     glyph_data: &[u8],
     number_of_contours: NonZeroU16,
-) -> Option<GlyphPointsIter> {
+) -> Option<GlyphPointsIter<'_>> {
     let mut s = Stream::new(glyph_data);
     let endpoints = s.read_array16::<u16>(number_of_contours.get())?;
 

--- a/src/tables/gpos.rs
+++ b/src/tables/gpos.rs
@@ -907,7 +907,7 @@ impl<'a> AnchorMatrix<'a> {
     }
 
     /// Returns an [`Anchor`] at position.
-    pub fn get(&self, row: u16, col: u16) -> Option<Anchor> {
+    pub fn get(&self, row: u16, col: u16) -> Option<Anchor<'_>> {
         let idx = u32::from(row) * u32::from(self.cols) + u32::from(col);
         let offset = self.matrix.get(idx)??.to_usize();
         Anchor::parse(self.data.get(offset..)?)

--- a/src/tables/math.rs
+++ b/src/tables/math.rs
@@ -45,7 +45,7 @@ impl FromData for MathValueRecord {
 }
 
 impl MathValueRecord {
-    fn get(self, data: &[u8]) -> MathValue {
+    fn get(self, data: &[u8]) -> MathValue<'_> {
         let device = self
             .device_offset
             .and_then(|offset| data.get(offset.to_usize()..))

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -420,7 +420,7 @@ impl<'a> Table<'a> {
         &self,
         axis: Tag,
         match_value: Option<Fixed>,
-    ) -> Option<AxisValueSubtable> {
+    ) -> Option<AxisValueSubtable<'_>> {
         for subtable in self.subtables() {
             match subtable {
                 AxisValueSubtable::Format1(AxisValueSubtableFormat1 {

--- a/src/var_store.rs
+++ b/src/var_store.rs
@@ -60,7 +60,7 @@ impl<'a> ItemVariationStore<'a> {
         })
     }
 
-    pub fn region_indices(&self, index: u16) -> Option<LazyArray16<u16>> {
+    pub fn region_indices(&self, index: u16) -> Option<LazyArray16<'_, u16>> {
         // Offsets in bytes from the start of the item variation store
         // to each item variation data subtable.
         let offset = self.data_offsets.get(index)?;


### PR DESCRIPTION
New lint in rust 1.89 warns when inferred lifetimes connect a parameter to a return value, but one of these is a struct written without '_.